### PR TITLE
Fix docker command line in consul guide

### DIFF
--- a/_guides/consul-config.adoc
+++ b/_guides/consul-config.adoc
@@ -37,7 +37,7 @@ There are various ways to start Consul that vary in complexity, but for the purp
 
 [source]
 ----
-docker run --rm --name consul -p 8500:8500 -p 8501:8501 consul:1.7 agent -dev -ui -client=0.0.0.0 -bind=0.0.0.0 --https-port=8501
+docker run --rm --name consul -p 8500:8500 -p 8501:8501 consul:1.7 agent -dev -ui -client 0.0.0.0 -bind 0.0.0.0 -https-port 8501
 ----
 
 Please consult the https://www.consul.io/docs/install[documentation] to learn more about the various Consul installation options.


### PR DESCRIPTION
Consul accepts command line parameters "--option=value" or "-option value"
The used notation "-client=0.0.0.0" is rejected by consul. The start fails.

** If you are updating a guide, please submit your pull request to the main repository: https://github.com/quarkusio/quarkus/tree/master/docs/src/main/asciidoc **
